### PR TITLE
Windows fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "gulp-util": "^3.0.0",
     "lazypipe": "^1.0.1",
+    "slash": "1.0.0",
     "tmp": "0.0.30",
     "vinyl-file": "^2.0.0"
   },


### PR DESCRIPTION
Added new function in javac.js to handle file paths on Windows only.  If platform is not win32, the original file path is returned.